### PR TITLE
Grouped Sorting

### DIFF
--- a/src/components/BreweryTable/BreweryTable.tsx
+++ b/src/components/BreweryTable/BreweryTable.tsx
@@ -15,7 +15,15 @@ const BreweryTable: FC = () => {
     return <p>Error: {error}</p>
   }
 
-  return <Table data={breweries} columns={columns} />
+  return (
+    <Table
+      data={breweries}
+      columns={columns}
+      groupBy='brewery_type'
+      sortBy='name'
+      sortOrder='asc'
+    />
+  )
 }
 
 export default BreweryTable

--- a/src/components/common/Table/Table.module.scss
+++ b/src/components/common/Table/Table.module.scss
@@ -3,17 +3,20 @@
   border-collapse: collapse;
 }
 
-.table th,
-.table td {
-  padding: 12px;
+.header {
+  background-color: #f4f4f4;
+  font-weight: bold;
   text-align: left;
+  padding: 8px;
+}
+
+.row {
+  &:nth-child(even) {
+    background-color: #f9f9f9;
+  }
+}
+
+.cell {
+  padding: 8px;
   border: 1px solid #ddd;
-}
-
-.table th {
-  background-color: #f2f2f2;
-}
-
-.table tr:hover {
-  background-color: #f5f5f5;
 }

--- a/src/components/common/Table/Table.tsx
+++ b/src/components/common/Table/Table.tsx
@@ -1,13 +1,26 @@
 import { FC } from 'react'
 import styles from './Table.module.scss'
+import useTable from './hooks/useTable'
 
 interface TableProps {
   data: Array<Record<string, any>>
   columns: Array<{ header: string; accessor: string }>
+  groupBy?: string
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
   onRowClick?: (row: Record<string, any>) => void
 }
 
-const Table: FC<TableProps> = ({ data, columns, onRowClick }) => {
+const Table: FC<TableProps> = ({
+  data,
+  columns,
+  groupBy = 'brewery_type',
+  sortBy = 'name',
+  sortOrder = 'asc',
+  onRowClick,
+}) => {
+  const { groupAndSortData } = useTable()
+
   return (
     <table className={styles.table}>
       <thead>
@@ -20,19 +33,21 @@ const Table: FC<TableProps> = ({ data, columns, onRowClick }) => {
         </tr>
       </thead>
       <tbody>
-        {data.map((row, rowIndex) => (
-          <tr
-            key={rowIndex}
-            className={styles.row}
-            onClick={() => onRowClick && onRowClick(row)}
-          >
-            {columns.map((column) => (
-              <td key={column.accessor} className={styles.cell}>
-                {row[column.accessor]}
-              </td>
-            ))}
-          </tr>
-        ))}
+        {groupAndSortData(data, groupBy, sortBy, sortOrder).map(
+          (row, rowIndex) => (
+            <tr
+              key={rowIndex}
+              className={styles.row}
+              onClick={() => onRowClick && onRowClick(row)}
+            >
+              {columns.map((column) => (
+                <td key={column.accessor} className={styles.cell}>
+                  {row[column.accessor]}
+                </td>
+              ))}
+            </tr>
+          )
+        )}
       </tbody>
     </table>
   )

--- a/src/components/common/Table/helper/groupAndSortData.ts
+++ b/src/components/common/Table/helper/groupAndSortData.ts
@@ -1,0 +1,25 @@
+// Helper function to sort data
+export const sortData = (a: any, b: any, key: string, sortOrder: string) => {
+  if (a[key] < b[key]) return sortOrder === 'asc' ? -1 : 1
+  if (a[key] > b[key]) return sortOrder === 'asc' ? 1 : -1
+  return 0
+}
+
+// Process data: group and sort
+export const groupAndSort = (
+  data: Array<Record<string, any>>,
+  groupBy: string,
+  sortBy: string,
+  sortOrder: string
+) => {
+  if (!data || data.length === 0) return []
+  const processedData = [...data].sort((a, b) => {
+    // Sort by group first if groupBy is provided
+    if (groupBy && a[groupBy] !== b[groupBy]) {
+      return sortData(a, b, groupBy, sortOrder)
+    }
+    // Then sort by the specified column
+    return sortBy ? sortData(a, b, sortBy, sortOrder) : 0
+  })
+  return processedData
+}

--- a/src/components/common/Table/hooks/useTable.ts
+++ b/src/components/common/Table/hooks/useTable.ts
@@ -1,0 +1,12 @@
+import { useCallback } from 'react'
+import { groupAndSort } from '../helper/groupAndSortData'
+
+const useTable = () => {
+  const groupAndSortData = useCallback(groupAndSort, [])
+
+  return {
+    groupAndSortData,
+  }
+}
+
+export default useTable


### PR DESCRIPTION
Sort the list of breweries alphabetically by name, grouped by brewery_type.

Brewery types should appear in alphabetical order, and breweries within each group should also be sorted alphabetically.

Acceptance Criteria:

- Breweries are grouped and displayed by brewery_type.
- Groups and their contents are sorted alphabetically by name.